### PR TITLE
Introduce new Status/phase: KILLING

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -48,7 +48,7 @@ public class ExecutableNode {
 
   private String id;
   private String type = null;
-  private Status status = Status.READY;
+  private volatile Status status = Status.READY;
   private long startTime = -1;
   private long endTime = -1;
   private long updateTime = -1;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1504,7 +1504,7 @@ public class ExecutorManager extends EventHandler implements
         continue;
         // case UNKNOWN:
       case READY:
-        node.setStatus(Status.KILLED);
+        node.setStatus(Status.KILLING);
         break;
       default:
         node.setStatus(Status.FAILED);

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -29,7 +29,8 @@ public enum Status {
   DISABLED(100),
   QUEUED(110),
   FAILED_SUCCEEDED(120),
-  CANCELLED(130);
+  CANCELLED(130),
+  KILLING(140);
 
   private final int numVal;
 

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -16,12 +16,16 @@
 
 package azkaban.executor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum Status {
   READY(10),
   PREPARING(20),
   RUNNING(30),
   PAUSED(40),
   SUCCEEDED(50),
+  KILLING(55),
   KILLED(60),
   FAILED(70),
   FAILED_FINISHING(80),
@@ -29,8 +33,17 @@ public enum Status {
   DISABLED(100),
   QUEUED(110),
   FAILED_SUCCEEDED(120),
-  CANCELLED(130),
-  KILLING(140);
+  CANCELLED(130);
+  // status is TINYINT and in H2 DB the possible values are: -128 to 127
+  // so trying to store CANCELLED in H2 fails at the moment
+
+  private static final Map<Integer, Status> numValMap = new HashMap<>();
+
+  static {
+    for (Status status : Status.values()) {
+      numValMap.put(status.getNumVal(), status);
+    }
+  }
 
   private final int numVal;
 
@@ -43,36 +56,10 @@ public enum Status {
   }
 
   public static Status fromInteger(int x) {
-    switch (x) {
-    case 10:
-      return READY;
-    case 20:
-      return PREPARING;
-    case 30:
-      return RUNNING;
-    case 40:
-      return PAUSED;
-    case 50:
-      return SUCCEEDED;
-    case 60:
-      return KILLED;
-    case 70:
-      return FAILED;
-    case 80:
-      return FAILED_FINISHING;
-    case 90:
-      return SKIPPED;
-    case 100:
-      return DISABLED;
-    case 110:
-      return QUEUED;
-    case 120:
-      return FAILED_SUCCEEDED;
-    case 130:
-      return CANCELLED;
-    default:
-      return READY;
+    if (numValMap.containsKey(x)) {
+      return numValMap.get(x);
     }
+    return READY;
   }
 
   public static boolean isStatusFinished(Status status) {
@@ -91,6 +78,7 @@ public enum Status {
 
   public static boolean isStatusRunning(Status status) {
     switch (status) {
+      // TODO maybe add KILLING here instead..
     case RUNNING:
     case FAILED_FINISHING:
     case QUEUED:

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/KillingMeSoftlyJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/KillingMeSoftlyJob.java
@@ -1,0 +1,73 @@
+package azkaban.jobExecutor;
+
+import azkaban.utils.Props;
+import org.apache.log4j.Logger;
+
+public class KillingMeSoftlyJob implements Job {
+
+  private final String jobid;
+  private final Props props;
+  private final Props jobProps;
+  private final Logger log;
+  private volatile boolean cancelled;
+
+  public KillingMeSoftlyJob(String jobid, Props props, Props jobProps, Logger log) {
+    this.jobid = jobid;
+    this.props = props;
+    this.jobProps = jobProps;
+    this.log = log;
+  }
+
+  @Override
+  public String getId() {
+    return jobid;
+  }
+
+  @Override
+  public void run() throws Exception {
+    info("KillingMeSoftlyJob run starts");
+    try {
+      Thread.sleep(5000L);
+    } catch (InterruptedException e) {
+      info("KillingMeSoftlyJob sleep was interrupted");
+    }
+    info("KillingMeSoftlyJob sleep ended");
+    if (isCanceled()) {
+      info("KillingMeSoftlyJob sleeping before exiting");
+      try {
+        Thread.sleep(5000L);
+      } catch (InterruptedException e) {
+        info("KillingMeSoftlyJob sleep was interrupted");
+      }
+      info("KillingMeSoftlyJob throwing cancelled exception");
+      throw new IllegalStateException("Job was cancelled!");
+    }
+    info("KillingMeSoftlyJob exiting");
+  }
+
+  private void info(String s) {
+    log.info(s);
+  }
+
+  @Override
+  public void cancel() throws Exception {
+    this.cancelled = true;
+    info("KillingMeSoftlyJob cancel was called");
+  }
+
+  @Override
+  public double getProgress() throws Exception {
+    return 0;
+  }
+
+  @Override
+  public Props getJobGeneratedProperties() {
+    return new Props();
+  }
+
+  @Override
+  public boolean isCanceled() {
+    return cancelled;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -16,6 +16,7 @@
 
 package azkaban.jobtype;
 
+import azkaban.jobExecutor.KillingMeSoftlyJob;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -95,6 +96,7 @@ public class JobTypeManager {
     logger.info("Loading plugin default job types");
     plugins.addPluginClass("command", ProcessJob.class);
     plugins.addPluginClass("javaprocess", JavaProcessJob.class);
+    plugins.addPluginClass("killingmesoftly", KillingMeSoftlyJob.class);
     plugins.addPluginClass("noop", NoopJob.class);
     plugins.addPluginClass("python", PythonJob.class);
     plugins.addPluginClass("ruby", RubyJob.class);

--- a/azkaban-common/src/main/java/azkaban/utils/WebUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/WebUtils.java
@@ -100,6 +100,8 @@ public class WebUtils {
       return "Paused";
     case SKIPPED:
       return "Skipped";
+    case KILLING:
+      return "Killing";
     default:
     }
     return "Unknown";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -497,7 +497,8 @@ public class FlowRunner extends EventHandler implements Runnable {
     boolean jobsRun = false;
     for (ExecutableNode node : nodesToCheck) {
       if (Status.isStatusFinished(node.getStatus())
-          || Status.isStatusRunning(node.getStatus())) {
+          || Status.isStatusRunning(node.getStatus())
+          || Status.KILLING == node.getStatus()) {
         // Really shouldn't get in here.
         continue;
       }
@@ -602,6 +603,7 @@ public class FlowRunner extends EventHandler implements Runnable {
       ExecutableNode node = flow.getExecutableNode(end);
 
       if (node.getStatus() == Status.KILLED
+          || node.getStatus() == Status.KILLING
           || node.getStatus() == Status.FAILED
           || node.getStatus() == Status.CANCELLED) {
         succeeded = false;
@@ -629,6 +631,10 @@ public class FlowRunner extends EventHandler implements Runnable {
         logger.info("Setting flow '" + id + "' status to FAILED in " + durationSec + " seconds");
         flow.setStatus(Status.FAILED);
       }
+      break;
+    case KILLING:
+      logger.info("Setting flow '" + id + "' status to KILLED in " + durationSec + " seconds");
+      flow.setStatus(Status.KILLED);
       break;
     case FAILED:
     case KILLED:
@@ -925,7 +931,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     synchronized (mainSyncObj) {
       if(flowKilled) return;
       logger.info("Kill has been called on flow " + execId);
-      flow.setStatus(Status.KILLED);
+      flow.setStatus(Status.KILLING);
       // If the flow is paused, then we'll also unpause
       flowPaused = false;
       flowKilled = true;
@@ -975,6 +981,8 @@ public class FlowRunner extends EventHandler implements Runnable {
         nodesToRetry.add(node);
         continue;
       } else if (node.getStatus() == Status.RUNNING) {
+        continue;
+      } else if (node.getStatus() == Status.KILLING) {
         continue;
       } else if (node.getStatus() == Status.SKIPPED) {
         node.setStatus(Status.DISABLED);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -701,6 +701,7 @@ public class JobRunner extends EventHandler implements Runnable {
     Status finalStatus = node.getStatus();
     try {
       job.run();
+      finalStatus = node.getStatus();
     } catch (Throwable e) {
       if (props.getBoolean("job.succeed.on.failure", false)) {
         finalStatus = changeStatus(Status.FAILED_SUCCEEDED);
@@ -723,7 +724,7 @@ public class JobRunner extends EventHandler implements Runnable {
     }
 
     // If the job is still running, set the status to Success.
-    if (!Status.isStatusFinished(finalStatus)) {
+    if (!Status.isStatusFinished(finalStatus) && finalStatus != Status.KILLING) {
       finalStatus = changeStatus(Status.SUCCEEDED);
     }
     return finalStatus;
@@ -757,6 +758,7 @@ public class JobRunner extends EventHandler implements Runnable {
         return;
       }
       logError("Kill has been called.");
+      this.changeStatus(Status.KILLING);
       this.killed = true;
 
       BlockingStatus status = currentBlockStatus;
@@ -781,7 +783,6 @@ public class JobRunner extends EventHandler implements Runnable {
         logError("Failed trying to cancel job. Maybe it hasn't started running yet or just finished.");
       }
 
-      this.changeStatus(Status.KILLED);
     }
   }
 

--- a/azkaban-web-server/src/main/less/azkaban-graph.less
+++ b/azkaban-web-server/src/main/less/azkaban-graph.less
@@ -94,6 +94,15 @@
   fill: #FFF;
 }
 
+.KILLING > g > rect {
+  fill: #FF9999;
+  stroke: #FF9999;
+}
+
+.KILLING > g > text {
+  fill: #FFF;
+}
+
 .CANCELLED > g > rect {
   fill: #FF9999;
   stroke: #FF9999;

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -65,6 +65,18 @@
     background-color: @flow-killed-color;
   }
 
+  // #ff9999 = killing vs. #3398cc = running
+  &.KILLING {
+    background-color: @flow-killing-color;
+    background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
+    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-size: 40px 40px;
+    -webkit-animation: progress-bar-stripes 2s linear infinite;
+            animation: progress-bar-stripes 2s linear infinite;
+  }
+
   &.RUNNING {
     background-color: @flow-running-color;
     background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
@@ -113,6 +125,10 @@ td {
 
     &.KILLED {
       background-color: @flow-killed-color;
+    }
+
+    &.KILLING {
+      background-color: @flow-killing-color;
     }
 
     &.PAUSED {
@@ -167,6 +183,10 @@ td {
 
   &.KILLED {
     color: @flow-killed-color;
+  }
+
+  &.KILLING {
+    color: @flow-killing-color;
   }
 
   &.CANCELLED {
@@ -307,6 +327,10 @@ li.tree-list-item {
     }
 
     &.KILLED .icon {
+      background-position: 0px 0px;
+    }
+
+    &.KILLING .icon {
       background-position: 0px 0px;
     }
 

--- a/azkaban-web-server/src/main/less/variables.less
+++ b/azkaban-web-server/src/main/less/variables.less
@@ -3,6 +3,7 @@
 @flow-succeeded-color: #5cb85c;
 @flow-failed-color: #d9534f;
 @flow-killed-color: #d9534f;
+@flow-killing-color: #ff9999;
 @flow-paused-color: #c82123;
 @flow-running-color: #3398cc;
 @flow-failed-finishing-color: #f19153;

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -197,6 +197,7 @@
                       <option value=30>Running</option>
                       <option value=40>Paused</option>
                       <option value=50>Succeed</option>
+                      <option value=55>Killing</option>
                       <option value=60>Killed</option>
                       <option value=70>Failed</option>
                       <option value=80>Failed Finishing</option>

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -24,6 +24,7 @@ var statusStringMap = {
   "FAILED_FINISHING": "Running w/Failure",
   "RUNNING": "Running",
   "WAITING": "Waiting",
+  "KILLING": "Killing",
   "KILLED": "Killed",
   "CANCELLED": "Cancelled",
   "DISABLED": "Disabled",

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -180,9 +180,9 @@ azkaban.FlowTabView = Backbone.View.extend({
 		if (data.status == "SUCCEEDED") {
                         $("#executebtn").show();
 		}
-                else if (data.status == "PREPARING") {
-                        $("#cancelbtn").show();
-                }
+		else if (data.status == "PREPARING") {
+						$("#cancelbtn").show();
+		}
 		else if (data.status == "FAILED") {
 			$("#executebtn").show();
 		}
@@ -205,6 +205,8 @@ azkaban.FlowTabView = Backbone.View.extend({
 		else if (data.status == "KILLED") {
 			$("#executebtn").show();
 		}
+    else if (data.status == "KILLING") {
+    }
 	},
 
 	handleCancelClick: function(evt) {
@@ -447,6 +449,10 @@ var updaterFunction = function() {
 			// 2 min updates
 			setTimeout(function() {updaterFunction();}, 2*60*1000);
 		}
+    else if (data.status == "KILLING") {
+      // 20 s updates
+      setTimeout(function() {updaterFunction();}, 30*1000);
+    }
 		else if (data.status != "SUCCEEDED" && data.status != "FAILED") {
 			// 2 min updates
 			setTimeout(function() {updaterFunction();}, 2*60*1000);

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-svg.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-svg.js
@@ -391,6 +391,9 @@ $(function() {
               if(obj.item.status == 50){
                 text[1] = "SUCCEEDED";
               }
+              else if(obj.item.status == 55){
+                text[1] = "KILLING";
+              }
               else if(obj.item.status == 60){
                 text[1] = "KILLED";
               }

--- a/azkaban-web-server/src/web/js/azkaban/view/time-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/time-graph.js
@@ -93,6 +93,9 @@ azkaban.TimeGraphView = Backbone.View.extend({
       else if (status == 'PAUSED') {
         return '#c92123';
       }
+      else if (status == 'KILLING') {
+        return '#ff9999';
+      }
       else if (status == 'FAILED' ||
           status == 'FAILED_FINISHING' ||
           status == 'KILLED') {


### PR DESCRIPTION
(Building on top of the fixed FlowRunnerTest, PR to origin about that pending here: https://github.com/azkaban/azkaban/pull/1115)

----

Implementation of https://github.com/azkaban/azkaban/issues/1122.

Related to https://github.com/azkaban/azkaban/issues/684.

New status transition after kill is called: -> KILLING -> KILLED.

Don't set the status to KILLED before all job threads have exited.

**TODO**: Also check once more all references to Status.KILLED in Java code.

**TODO** have this merged first \& then rebase on it: https://github.com/azkaban/azkaban/pull/1119

----

![nayttokuva 2017-05-26 kello 16 03 05](https://cloud.githubusercontent.com/assets/4446608/26495679/2b8e70aa-422d-11e7-8400-ab0ac1b37959.png)

![nayttokuva 2017-05-26 kello 16 02 26](https://cloud.githubusercontent.com/assets/4446608/26495664/1fd2c16c-422d-11e7-80cc-6bd6b92dca28.png)

![nayttokuva 2017-05-26 kello 16 02 47](https://cloud.githubusercontent.com/assets/4446608/26495674/260dd3e6-422d-11e7-8ed5-b160c19ba3ff.png)